### PR TITLE
Remove `.html` from Coming Soon link

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -3,7 +3,7 @@ Coming Soon:
   <% for(var slug in public.episodes._data){ %>
     <% if (public.episodes._data[slug].upcoming) { %>
     <% if (public.episodes._data[slug].guestLink) { %>
-      <a href="<%= public.episodes._data[slug].guestLink %>.html"><%= public.episodes._data[slug].guest %></a>
+      <a href="<%= public.episodes._data[slug].guestLink %>"><%= public.episodes._data[slug].guest %></a>
     <% } else { %>
         <%= public.episodes._data[slug].guest %>
     <% } %>


### PR DESCRIPTION
Currently this is making the "Coming Soon" link point to "https://codeascraft.com/.html" which comes back 403 Forbidden. Based on `public/episodes/_data.json` it seems like it should simply just include the URL.